### PR TITLE
Fix bug causing userdefaults with 0 to fail.

### DIFF
--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -27,7 +27,7 @@ def load_current_resource
   @userdefaults.domain(new_resource.domain)
   Chef::Log.debug("Checking #{new_resource.domain} value")
   truefalse = 1 if ['TRUE','1','true','YES','yes'].include?(new_resource.value)
-  truefalse = 0 if ['FALSE','0','false','NO','no'].include?(new.resource.value)
+  truefalse = 0 if ['FALSE','0','false','NO','no'].include?(new_resource.value)
   drcmd = "defaults read #{new_resource.domain} "
   drcmd << "-g " if new_resource.global
   drcmd << "#{new_resource.key} " if new_resource.key


### PR DESCRIPTION
I found it when trying to disable autosubmit in 1Password.

mac_os_x_userdefaults "disable autosubmit in 1Password" do
  domain "ws.agile.1Password"
  key "autosubmit"
  type "int"
  value "0"
end
