### PR TITLE
Add `user` resource attr to `mac_os_x_userdefaults`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Manage the Mac OS X user defaults(1) system. The parameters to the resource are 
 - key: The preference key. Required.
 - value: The value of the key. Required.
 - type: Value type of the preference key.
+- user: User for which to set the default.
 - sudo: Set to true if the setting requires privileged access to modify. Default false.
 
 `value` settings of `1`, `TRUE`, `true`, `YES` or `yes` are treated as true by defaults(1), and are handled in the provider.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,3 @@ license          "Apache 2.0"
 description      "Manage OS X user defaults settings"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.3.6"
-supports         "mac_os_x"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,3 +4,4 @@ license          "Apache 2.0"
 description      "Manage OS X user defaults settings"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.3.6"
+supports         "mac_os_x"

--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -31,7 +31,9 @@ def load_current_resource
   drcmd = "defaults read #{new_resource.domain} "
   drcmd << "-g " if new_resource.global
   drcmd << "#{new_resource.key} " if new_resource.key
-  v = shell_out("#{drcmd} | grep -qx '#{truefalse || new_resource.value}'")
+  shell_out_opts = {}
+  shell_out_opts[:user] = new_resource.user unless new_resource.user.nil?
+  v = shell_out("#{drcmd} | grep -qx '#{truefalse || new_resource.value}'", shell_out_opts)
   is_set = v.exitstatus == 0 ? true : false
   @userdefaults.is_set(is_set)
 end

--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -65,6 +65,8 @@ action :write do
 
     cmd << "-#{type}" if type
     cmd << value
-    execute cmd.join(' ')
+    execute cmd.join(' ') do
+      user new_resource.user unless new_resource.user.nil?
+    end
   end
 end

--- a/resources/userdefaults.rb
+++ b/resources/userdefaults.rb
@@ -24,6 +24,7 @@ attribute :global, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :key, :kind_of => String, :default => nil
 attribute :value, :kind_of => [Integer,String,TrueClass,FalseClass,Hash], :default => nil, :required => true
 attribute :type, :kind_of => String, :default => nil
+attribute :user, :kind_of => String, :default => nil
 attribute :sudo, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :is_set, :kind_of => [TrueClass, FalseClass], :default => false
 


### PR DESCRIPTION
This will allow pivotal_workstation to use `mac_os_x` as a dependency, as they rely on chef being run as sudo but still adjusting the sudo'ing user's defaults.

Related: pivotal/pivotal_workstation#63
