### PR TITLE
Booleans should be correctly recognized in userdefaults

### DIFF
--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -26,8 +26,8 @@ def load_current_resource
   @userdefaults.key(new_resource.key)
   @userdefaults.domain(new_resource.domain)
   Chef::Log.debug("Checking #{new_resource.domain} value")
-  truefalse = 1 if ['TRUE','1','true','YES','yes'].include?(new_resource.value)
-  truefalse = 0 if ['FALSE','0','false','NO','no'].include?(new_resource.value)
+  truefalse = 1 if [true, 'TRUE','1','true','YES','yes'].include?(new_resource.value)
+  truefalse = 0 if [false, 'FALSE','0','false','NO','no'].include?(new_resource.value)
   drcmd = "defaults read #{new_resource.domain} "
   drcmd << "-g " if new_resource.global
   drcmd << "#{new_resource.key} " if new_resource.key


### PR DESCRIPTION
If you would set preferences as booleans like in the example below, the userdefaults provider would always set the setting again. `true` and `false` (being `TrueClass` and `FalseClass`) would not be recognized as a boolean and causing the check to fail.

``` ruby
node.default['mac_os_x']['settings']['finder'] = {
  "ShowStatusBar" => true,
}
```

When adding them as a boolean the preferences are only set if they are different than the current value.

A workaround would be to define the booleans as strings: `"ShowStatusBar" => "true"`. But that seems a bit lame too.
