### PR TITLE
Put key in quotes while running defaults read command

### DIFF
--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -28,7 +28,7 @@ def load_current_resource
   Chef::Log.debug("Checking #{new_resource.domain} value")
   truefalse = 1 if [true, 'TRUE','1','true','YES','yes'].include?(new_resource.value)
   truefalse = 0 if [false, 'FALSE','0','false','NO','no'].include?(new_resource.value)
-  drcmd = "defaults read #{new_resource.domain} "
+  drcmd = "defaults read '#{new_resource.domain}' "
   drcmd << "-g " if new_resource.global
   drcmd << "'#{new_resource.key}' " if new_resource.key
   shell_out_opts = {}
@@ -46,7 +46,7 @@ action :write do
     if new_resource.global
       cmd << "NSGlobalDomain"
     else
-      cmd << new_resource.domain
+      cmd << "'#{new_resource.domain}'"
     end
 
     cmd << "'#{new_resource.key}'" if new_resource.key


### PR DESCRIPTION
Some keys have spaces in them causing the `defaults read` command to fail. This would result in the script always setting the value, even if it hadn't changed.
