### PR TITLE
Don't add '-g' to defaults read command for NSGlobalDomain

### DIFF
--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -29,7 +29,6 @@ def load_current_resource
   truefalse = 1 if [true, 'TRUE','1','true','YES','yes'].include?(new_resource.value)
   truefalse = 0 if [false, 'FALSE','0','false','NO','no'].include?(new_resource.value)
   drcmd = "defaults read '#{new_resource.domain}' "
-  drcmd << "-g " if new_resource.global
   drcmd << "'#{new_resource.key}' " if new_resource.key
   shell_out_opts = {}
   shell_out_opts[:user] = new_resource.user unless new_resource.user.nil?


### PR DESCRIPTION
Reading defaults of `NSGlobalDomain` fails. The provider would add a `-g` option when reading `NSGlobalDomain` defaults, which causes the command to fail and causes the provider to always set the value even if it hasn't changed.
This is what the provider does:

```
defaults read NSGlobalDomain -g NSAllowContinuousSpellChecking
=> The domain/default pair of (kCFPreferencesAnyApplication, -g) does not exist
```

Using both `NSGlobalDomain` and `-g` doesn't work (anymore?)
The following commands both correctly return the current value:

```
defaults read NSGlobalDomain NSAllowContinuousSpellChecking
defaults read -g NSAllowContinuousSpellChecking
```

Here is the issue I've created in the chef ticketing system. It this required for me to do, or can I just create pull requests to this repository?
https://tickets.opscode.com/browse/COOK-3585
