### PR TITLE
Complex array values break unless quoted.

### DIFF
--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -71,7 +71,7 @@ action :write do
     end
 
     cmd << "-#{type}" if type
-    cmd << "#{value}"
+    cmd << value
     execute cmd.join(' ') do
       user new_resource.user unless new_resource.user.nil?
     end


### PR DESCRIPTION
When passing complex (e.g. multi-line) array values, `defaults write` errors unless they're properly quoted. This change fixes that, with no ill effects that I can see.
