### PR TITLE
add default attribute to set the 'user' attribute for userdefaults

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,11 @@
 # limitations under the License.
 #
 
+# use this user as the default for all reads/writes, unless overridden with sudo or user
+# using nil leaves the default behavior the same as before
+node.default['mac_os_x']['user'] = nil
+
+# for the ::settings recipe
 node.default['mac_os_x']['settings_user'] = node['current_user']
 node.default['mac_os_x']['settings'] = {}
 

--- a/resources/userdefaults.rb
+++ b/resources/userdefaults.rb
@@ -24,7 +24,7 @@ attribute :global, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :key, :kind_of => String, :default => nil
 attribute :value, :kind_of => [Integer,Float,String,TrueClass,FalseClass,Hash,Array], :default => nil, :required => true
 attribute :type, :kind_of => String, :default => nil
-attribute :user, :kind_of => String, :default => nil
+attribute :user, :kind_of => String, :default => node['mac_os_x']['user']
 attribute :sudo, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :is_set, :kind_of => [TrueClass, FalseClass], :default => false
 


### PR DESCRIPTION
tl;dr - similar to what #21 wants, but less specific - allow the "user" attribute to be set/overridden globally.

trying to use mac_os_x_userdefaults with kitchenplan resulted in...interesting failures.    (kitchenplan's own defaults write doesnt support notifies sanely - and I didnt want to rewrite it).    turns out kitchenplan runs solo under sudo.   so my user level settings were getting set for root, instead of me.    kitchenplan does set a correct node['current_user'], though, so I don't need a mixin to get the right user.  

To avoid any change to default behaviors, updated the userdefaults :user attribute to consume the new cookbook attribute.  This still defaults to nil, so should have zero impact.

For users who want to make the change - simply override node['mac_os_x']['user'] in your role/attributes/cookbook or whatever you prefer.   You can even use the cool chef 12 homebrew mixin - http://jtimberman.housepub.org/blog/2014/12/29/chef-12-homebrew-user-mixin/  :)
