### PR TITLE
Support for "-currentHost" flag, "CINK002" rule fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.4.7:
+* Support for `-currentHost` flag
+* Changing double-quoted strings to single-quoted (FoodCritic's `CINK002` rule)
+
 ## v1.4.4:
 
 * Booleans should be correctly recognized in userdefaults (#13)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ A setting that uses an int (integer) type.
       type 'int'
     end
 
-Disable Screen Saver (uses '-currentHost' flag).
+Disable Screen Saver for particular user (uses '-currentHost' flag).
 
     mac_os_x_userdefaults 'Disable Screen Saver' do
       host '-currentHost'
@@ -121,6 +121,7 @@ Disable Screen Saver (uses '-currentHost' flag).
       key 'idleTime'
       type 'int'
       value 0
+      user 'username'
     end
 
 LWRP's can send notifications, so we can change the Dock, and then

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ For example, some 'dock' settings (for com.apple.dock):
 
 ```ruby
 node.default['mac_os_x']['settings']['dock'] = {
-  "domain" => "com.apple.dock",
-  "no-glass" => true,
-  "autohide" => true,
-  "showhidden" => true
+  'domain' => 'com.apple.dock',
+  'no-glass' => true,
+  'autohide' => true,
+  'showhidden' => true
 }
 ```
 
@@ -59,6 +59,7 @@ detail on how the tool works.
 
 - domain: The domain the defaults belong to. Required. Name attribute.
 - global: Whether the domain is global. Can be true or false. Default false.
+- host: Adds flag to restrict preferences operations. Default is empty (no flag)
 - key: The preference key. Required.
 - value: The value of the key. Required.
 - type: Value type of the preference key.
@@ -80,61 +81,71 @@ The current version cannot handle plists or dictionaries.
 Simple example that uses the `com.apple.systempreferences` domain,
 with a single key and value.
 
-    mac_os_x_userdefaults "enable time machine on unsupported volumes" do
-      domain "com.apple.systempreferences"
-      key "TMShowUnsupportedNetworkVolumes"
+    mac_os_x_userdefaults 'enable time machine on unsupported volumes' do
+      domain 'com.apple.systempreferences'
+      key 'TMShowUnsupportedNetworkVolumes'
       value "1"
     end
 
 Specify a global domain. Note that the key is not required for global domains.
 
-    mac_os_x_userdefaults "full keyboard access to all controls" do
-      domain "AppleKeyboardUIMode"
+    mac_os_x_userdefaults 'full keyboard access to all controls' do
+      domain 'AppleKeyboardUIMode'
       global true
-      value "2"
+      value '2'
     end
 
 A boolean type that uses truthiness (TRUE).
 
-    mac_os_x_userdefaults "finder expanded save dialogs" do
-      domain "NSNavPanelExpandedStateForSaveMode"
+    mac_os_x_userdefaults 'finder expanded save dialogs' do
+      domain 'NSNavPanelExpandedStateForSaveMode'
       global true
-      value "TRUE"
-      type "bool"
+      value 'TRUE'
+      type 'bool'
     end
 
 A setting that uses an int (integer) type.
 
-    mac_os_x_userdefaults "enable OS X firewall" do
-      domain "/Library/Preferences/com.apple.alf"
-      key "globalstate"
-      value "1"
-      type "int"
+    mac_os_x_userdefaults 'enable OS X firewall' do
+      domain '/Library/Preferences/com.apple.alf'
+      key 'globalstate'
+      value '1'
+      type 'int'
+    end
+
+Disable Screen Saver (uses '-currentHost' flag).
+
+    mac_os_x_userdefaults 'Disable Screen Saver' do
+      host '-currentHost'
+      domain 'com.apple.screensaver'
+      key 'idleTime'
+      type 'int'
+      value 0
     end
 
 LWRP's can send notifications, so we can change the Dock, and then
 refresh it to take effect.
 
-    execute "killall Dock" do
+    execute 'killall Dock' do
       action :nothing
     end
 
-    mac_os_x_userdefaults "set dock size" do
-      domain "com.apple.dock"
-      type "integer"
-      key "tilesize"
-      value "20"
-      notifies :run, "execute[killall Dock]"
+    mac_os_x_userdefaults 'set dock size' do
+      domain 'com.apple.dock'
+      type 'integer'
+      key 'tilesize'
+      value '20'
+      notifies :run, 'execute[killall Dock]'
     end
 
 This setting requires privileged access to modify, so tell it to use
 sudo. Note that this will prompt for the user password if sudo hasn't
 been modified for NOPASSWD.
 
-    mac_os_x_userdefaults "disable time machine normal schedule" do
-      domain "/System/Library/LaunchDaemons/com.apple.backupd-auto"
-      key "Disabled"
-      value "1"
+    mac_os_x_userdefaults 'disable time machine normal schedule' do
+      domain '/System/Library/LaunchDaemons/com.apple.backupd-auto'
+      key 'Disabled'
+      value '1'
       sudo true
     end
 
@@ -160,7 +171,7 @@ Chef.
 Write the iTerm 2 preferences to
 `~/Library/Preferences/com.googlecode.iterm2.plist`.
 
-    mac_os_x_plist_file "com.googlecode.iterm2.plist"
+    mac_os_x_plist_file 'com.googlecode.iterm2.plist'
 
 Recipes
 =======

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,8 @@
-name             "mac_os_x"
-maintainer       "Joshua Timberman"
-maintainer_email "cookbooks@housepub.org"
-license          "Apache 2.0"
-description      "Manage OS X user defaults settings"
+name             'mac_os_x'
+maintainer       'Joshua Timberman'
+maintainer_email 'cookbooks@housepub.org'
+license          'Apache 2.0'
+description      'Manage OS X user defaults settings'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.4.5"
-supports         "mac_os_x"
+version          '1.4.7'
+supports         'mac_os_x'

--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -28,7 +28,7 @@ def load_current_resource
   Chef::Log.debug("Checking #{new_resource.domain} value")
   truefalse = 1 if [true, 'TRUE','1','true','YES','yes'].include?(new_resource.value)
   truefalse = 0 if [false, 'FALSE','0','false','NO','no'].include?(new_resource.value)
-  drcmd = "defaults read '#{new_resource.domain}' "
+  drcmd = "defaults #{new_resource.host} read '#{new_resource.domain}' "
   drcmd << "'#{new_resource.key}' " if new_resource.key
   shell_out_opts = {}
   shell_out_opts[:user] = new_resource.user unless new_resource.user.nil?
@@ -39,11 +39,11 @@ end
 
 action :write do
   unless @userdefaults.is_set
-    cmd = ["defaults write"]
+    cmd = ["defaults #{new_resource.host} write"]
     cmd.unshift('sudo') if new_resource.sudo
 
     if new_resource.global
-      cmd << "NSGlobalDomain"
+      cmd << 'NSGlobalDomain'
     else
       cmd << "'#{new_resource.domain}'"
     end

--- a/recipes/autoupdate.rb
+++ b/recipes/autoupdate.rb
@@ -18,10 +18,10 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "enable autoupdates" do
-  domain "/Library/Preferences/com.apple.SoftwareUpdate"
-  key "AutomaticCheckEnabled"
-  value "1"
-  type "int"
+mac_os_x_userdefaults 'enable autoupdates' do
+  domain '/Library/Preferences/com.apple.SoftwareUpdate'
+  key 'AutomaticCheckEnabled'
+  value '1'
+  type 'int'
   sudo true
 end

--- a/recipes/dock_preferences.rb
+++ b/recipes/dock_preferences.rb
@@ -22,24 +22,24 @@
 %w{ autohide magnification workspaces-swoosh-animation-off }.each do |dock|
 
   mac_os_x_userdefaults "com.apple.dock #{dock}" do
-    domain "com.apple.dock"
+    domain 'com.apple.dock'
     key dock
-    value "true"
-    type "boolean"
+    value 'true'
+    type 'boolean'
     notifies :run, 'execute[killall Dock]'
   end
 
 end
 
-mac_os_x_userdefaults "com.apple.dock tile size" do
-  domain "com.apple.dock"
-  key "tilesize"
-  value "20"
-  type "integer"
+mac_os_x_userdefaults 'com.apple.dock tile size' do
+  domain 'com.apple.dock'
+  key 'tilesize'
+  value '20'
+  type 'integer'
   notifies :run, 'execute[killall Dock]'
 end
 
-execute "killall Dock" do
+execute 'killall Dock' do
   ignore_failure true
   action :nothing
 end

--- a/recipes/finder.rb
+++ b/recipes/finder.rb
@@ -19,25 +19,25 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "finder expanded save dialogs" do
-  key "NSNavPanelExpandedStateForSaveMode"
-  type "bool"
+mac_os_x_userdefaults 'finder expanded save dialogs' do
+  key 'NSNavPanelExpandedStateForSaveMode'
+  type 'bool'
   value true
   global true
 end
 
-mac_os_x_userdefaults "dont show hard drives on the desktop" do
-  domain "com.apple.finder"
-  key "ShowHardDrivesOnDesktop"
+mac_os_x_userdefaults 'dont show hard drives on the desktop' do
+  domain 'com.apple.finder'
+  key 'ShowHardDrivesOnDesktop'
   value false
-  type "bool"
+  type 'bool'
 end
 
-mac_os_x_userdefaults "show all files in Finder" do
-  domain "com.apple.finder"
-  key "AppleShowAllFiles"
+mac_os_x_userdefaults 'show all files in Finder' do
+  domain 'com.apple.finder'
+  key 'AppleShowAllFiles'
   value false
-  type "bool"
+  type 'bool'
 end
 
 # TODO:

--- a/recipes/firewall.rb
+++ b/recipes/firewall.rb
@@ -19,10 +19,10 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "enable OS X firewall" do
-  domain "/Library/Preferences/com.apple.alf"
-  key "globalstate"
-  value "1"
-  type "int"
+mac_os_x_userdefaults 'enable OS X firewall' do
+  domain '/Library/Preferences/com.apple.alf'
+  key 'globalstate'
+  value '1'
+  type 'int'
   sudo true
 end

--- a/recipes/itunes.rb
+++ b/recipes/itunes.rb
@@ -19,9 +19,9 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "Search iTunes locally" do
-  domain "com.apple.iTunes"
-  key "invertStoreLinks"
+mac_os_x_userdefaults 'Search iTunes locally' do
+  domain 'com.apple.iTunes'
+  key 'invertStoreLinks'
   value true
-  type "bool"
+  type 'bool'
 end

--- a/recipes/kbaccess.rb
+++ b/recipes/kbaccess.rb
@@ -19,9 +19,9 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "Full Keyboard Access to All Controls" do
-  key "AppleKeyboardUIMode"
+mac_os_x_userdefaults 'Full Keyboard Access to All Controls' do
+  key 'AppleKeyboardUIMode'
   global true
-  type "int"
+  type 'int'
   value 2
 end

--- a/recipes/key_repeat.rb
+++ b/recipes/key_repeat.rb
@@ -19,16 +19,16 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "set key repeat rate to fast" do
-  domain "~/Library/Preferences/.GlobalPreferences"
-  key "KeyRepeat"
-  type "int"
+mac_os_x_userdefaults 'set key repeat rate to fast' do
+  domain '~/Library/Preferences/.GlobalPreferences'
+  key 'KeyRepeat'
+  type 'int'
   value 2
 end
 
-mac_os_x_userdefaults "set key initial repeat delay to short" do
-  domain "~/Library/Preferences/.GlobalPreferences"
-  key "InitialKeyRepeat"
-  type "int"
+mac_os_x_userdefaults 'set key initial repeat delay to short' do
+  domain '~/Library/Preferences/.GlobalPreferences'
+  key 'InitialKeyRepeat'
+  type 'int'
   value 15
 end

--- a/recipes/lion_ical.rb
+++ b/recipes/lion_ical.rb
@@ -19,30 +19,30 @@
 # limitations under the License.
 #
 
-ruby_block "Backup iCal" do
+ruby_block 'Backup iCal' do
   block do
-    ::FileUtils.cp_r("/Applications/iCal.app", "/Applications/iCal-copy.app")
+    ::FileUtils.cp_r('/Applications/iCal.app', '/Applications/iCal-copy.app')
   end
-  not_if {File.directory?("/Applications/iCal-copy.app")}
+  not_if {File.directory?('/Applications/iCal-copy.app')}
 end
 
 remote_file "#{Chef::Config[:file_cache_path]}/inmdin.zip" do
-  source "https://files.me.com/eduncle/inmdin"
-  checksum "8ede2aebf5271ce44a0093aefd5bd9484c5f3c2cca07212fa415d7988ba593d2"
-  notifies :run, "execute[unzip inmdin.zip]", :immediately
+  source 'https://files.me.com/eduncle/inmdin'
+  checksum '8ede2aebf5271ce44a0093aefd5bd9484c5f3c2cca07212fa415d7988ba593d2'
+  notifies :run, 'execute[unzip inmdin.zip]', :immediately
 end
 
-execute "unzip inmdin.zip" do
+execute 'unzip inmdin.zip' do
   cwd Chef::Config[:file_cache_path]
   action :nothing
-  notifies :create, "ruby_block[Aluminum iCal]", :immediately
+  notifies :create, 'ruby_block[Aluminum iCal]', :immediately
 end
 
-ruby_block "Aluminum iCal" do
+ruby_block 'Aluminum iCal' do
   block do
-    theme_dir = "10.7-Lion-iCal-Aluminium-Skin-v2"
+    theme_dir = '10.7-Lion-iCal-Aluminium-Skin-v2'
     ::FileUtils.cp_r("#{Chef::Config[:file_cache_path]}/#{theme_dir}",
-                     "/Applications/iCal.app/Contents/Resources")
+                     '/Applications/iCal.app/Contents/Resources')
   end
   action :nothing
 end

--- a/recipes/lion_mail.rb
+++ b/recipes/lion_mail.rb
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-execute "Set Mail.app Archive to cmd-Y" do
+execute 'Set Mail.app Archive to cmd-Y' do
   command "defaults write com.apple.mail NSUserKeyEquivalents -dict-add Archive '@y'"
   not_if "defaults read com.apple.mail NSUserKeyEquivalents 2>&1 | grep -q '.*Archive = \"@y\"'"
 end
@@ -26,10 +26,10 @@ end
 %w[Reply Send].each do |animation|
 
   mac_os_x_userdefaults "Disable Lions mail #{animation} animation" do
-    domain "com.apple.Mail"
+    domain 'com.apple.Mail'
     key "Disable#{animation}Animations"
-    value "yes"
-    type "bool"
+    value 'yes'
+    type 'bool'
   end
 
 end

--- a/recipes/lion_tweaks.rb
+++ b/recipes/lion_tweaks.rb
@@ -20,70 +20,70 @@
 #
 unless node['platform_version'].to_f < 10.7
 
-  include_recipe "mac_os_x::lion_mail"
+  include_recipe 'mac_os_x::lion_mail'
 
-  execute "killall Dock" do
+  execute 'killall Dock' do
     action :nothing
   end
 
-  mac_os_x_userdefaults "Disable Launchpad gesture" do
-    domain "com.apple.dock"
-    key "showLaunchpadGestureEnabled"
-    type "bool"
+  mac_os_x_userdefaults 'Disable Launchpad gesture' do
+    domain 'com.apple.dock'
+    key 'showLaunchpadGestureEnabled'
+    type 'bool'
     value false
-    notifies :run, "execute[killall Dock]"
+    notifies :run, 'execute[killall Dock]'
   end
 
-  mac_os_x_userdefaults "Translucent hidden Dock icons" do
-    domain "com.apple.Dock"
-    key "showhidden"
+  mac_os_x_userdefaults 'Translucent hidden Dock icons' do
+    domain 'com.apple.Dock'
+    key 'showhidden'
     value true
-    type "bool"
+    type 'bool'
   end
 
-  mac_os_x_userdefaults "0 Duration for Mission Control animation" do
-    domain "com.apple.dock"
-    key "expose-animation-duration"
-    type "int"
+  mac_os_x_userdefaults '0 Duration for Mission Control animation' do
+    domain 'com.apple.dock'
+    key 'expose-animation-duration'
+    type 'int'
     value false
-    notifies :run, "execute[killall Dock]"
+    notifies :run, 'execute[killall Dock]'
   end
 
-  mac_os_x_userdefaults "Double tap switch spaces" do
-    domain "com.apple.dock"
-    key "double-tap-jump-back"
-    type "bool"
+  mac_os_x_userdefaults 'Double tap switch spaces' do
+    domain 'com.apple.dock'
+    key 'double-tap-jump-back'
+    type 'bool'
     value true
-    notifies :run, "execute[killall Dock]"
+    notifies :run, 'execute[killall Dock]'
   end
 
   mac_os_x_userdefaults "Don't automatically rearrange spaces" do
-    domain "com.apple.dock"
-    key "mru-spaces"
-    type "bool"
+    domain 'com.apple.dock'
+    key 'mru-spaces'
+    type 'bool'
     value false
-    notifies :run, "execute[killall Dock]"
+    notifies :run, 'execute[killall Dock]'
   end
 
-  mac_os_x_userdefaults "Disable Lions window animations" do
-    domain "NSGlobalDomain"
-    key "NSAutomaticWindowAnimationsEnabled"
-    type "bool"
+  mac_os_x_userdefaults 'Disable Lions window animations' do
+    domain 'NSGlobalDomain'
+    key 'NSAutomaticWindowAnimationsEnabled'
+    type 'bool'
     value false
-    only_if "defaults read NSGlobalDomain NSAutomaticWindowAnimationsEnabled"
+    only_if 'defaults read NSGlobalDomain NSAutomaticWindowAnimationsEnabled'
   end
 
-  mac_os_x_userdefaults "Disable keyboard press and hold" do
-    key "ApplePressAndHoldEnabled"
+  mac_os_x_userdefaults 'Disable keyboard press and hold' do
+    key 'ApplePressAndHoldEnabled'
     value false
     global true
   end
 
-  mac_os_x_userdefaults "Disable automatic spelling correction" do
-    domain "NSGlobalDomain"
-    key "NSAutomaticSpellingCorrectionEnabled"
+  mac_os_x_userdefaults 'Disable automatic spelling correction' do
+    domain 'NSGlobalDomain'
+    key 'NSAutomaticSpellingCorrectionEnabled'
     value false
-    type "bool"
+    type 'bool'
   end
 
   %w{WebAutomaticDashSubstitutionEnabled
@@ -93,22 +93,22 @@ unless node['platform_version'].to_f < 10.7
     mac_os_x_userdefaults "Disable #{text}" do
       key text
       value false
-      type "bool"
+      type 'bool'
       global true
     end
   end
 
-  mac_os_x_userdefaults "Disable AirDrop" do
-    domain "com.apple.NetworkBrowser"
-    key "DisableAirDrop"
+  mac_os_x_userdefaults 'Disable AirDrop' do
+    domain 'com.apple.NetworkBrowser'
+    key 'DisableAirDrop'
     value true
-    type "bool"
+    type 'bool'
   end
 
-  mac_os_x_userdefaults "Always show scrollbars" do
-    key "AppleShowScrollBars"
-    type "string"
-    value "Always"
+  mac_os_x_userdefaults 'Always show scrollbars' do
+    key 'AppleShowScrollBars'
+    type 'string'
+    value 'Always'
     global true
   end
 

--- a/recipes/locatedb.rb
+++ b/recipes/locatedb.rb
@@ -18,6 +18,6 @@
 # limitations under the License.
 #
 
-service "com.apple.locate" do
+service 'com.apple.locate' do
   action :start
 end

--- a/recipes/screensaver.rb
+++ b/recipes/screensaver.rb
@@ -19,16 +19,16 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "password protected screensaver" do
-  domain "com.apple.screensaver"
-  key "askForPassword"
-  type "int"
+mac_os_x_userdefaults 'password protected screensaver' do
+  domain 'com.apple.screensaver'
+  key 'askForPassword'
+  type 'int'
   value 1
 end
 
-mac_os_x_userdefaults "password protected screensaver delay" do
-  domain "com.apple.screensaver"
-  key "askForPasswordDelay"
-  type "int"
+mac_os_x_userdefaults 'password protected screensaver delay' do
+  domain 'com.apple.screensaver'
+  key 'askForPasswordDelay'
+  type 'int'
   value 5
 end

--- a/recipes/settings.rb
+++ b/recipes/settings.rb
@@ -21,7 +21,7 @@
 # limitations under the License.
 #
 
-execute "killall Dock" do
+execute 'killall Dock' do
   action :nothing
 end
 
@@ -36,7 +36,7 @@ node['mac_os_x']['settings'].each do |domain,settings|
       value v
       sudo true if settings['domain'] =~ /^\/Library\/Preferences/
       global true if settings['domain'] =~ /^NSGlobalDomain$/
-      notifies :run, "execute[killall Dock]" if settings['domain'] =~ /^com.apple.dock$/
+      notifies :run, 'execute[killall Dock]' if settings['domain'] =~ /^com.apple.dock$/
     end
   end
 end

--- a/recipes/time_machine.rb
+++ b/recipes/time_machine.rb
@@ -19,8 +19,8 @@
 # limitations under the License.
 #
 
-mac_os_x_userdefaults "enable time machine on NAS" do
-  domain "com.apple.systempreferences"
-  key "TMShowUnsupportedNetworkVolumes"
-  value "1"
+mac_os_x_userdefaults 'enable time machine on NAS' do
+  domain 'com.apple.systempreferences'
+  key 'TMShowUnsupportedNetworkVolumes'
+  value '1'
 end

--- a/resources/plist_file.rb
+++ b/resources/plist_file.rb
@@ -20,7 +20,7 @@
 actions :create
 
 attribute :source, :kind_of => String, :name_attribute => true
-attribute :cookbook, :kind_of => String, :default => ""
+attribute :cookbook, :kind_of => String, :default => ''
 
 def initialize(*args)
   super

--- a/resources/userdefaults.rb
+++ b/resources/userdefaults.rb
@@ -21,6 +21,7 @@ actions :write
 
 attribute :domain, :kind_of => String, :name_attribute => true, :required => true
 attribute :global, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :host, :kind_of => String, :default => nil
 attribute :key, :kind_of => String, :default => nil
 attribute :value, :kind_of => [Integer,Float,String,TrueClass,FalseClass,Hash,Array], :default => nil, :required => true
 attribute :type, :kind_of => String, :default => nil


### PR DESCRIPTION
Next improvements: 1) Support for "-currentHost" flag, 2) Changing double-quoted strings to single-quoted (FoodCritic's "CINK002" rule)
